### PR TITLE
swarm/network: expose simulation RandomUpNode to use in stream tests

### DIFF
--- a/swarm/network/simulation/connect.go
+++ b/swarm/network/simulation/connect.go
@@ -54,7 +54,7 @@ func (s *Simulation) ConnectToLastNode(id discover.NodeID) (err error) {
 // ConnectToRandomNode connects the node with provieded NodeID
 // to a random node that is up.
 func (s *Simulation) ConnectToRandomNode(id discover.NodeID) (err error) {
-	n := s.randomUpNode(id)
+	n := s.RandomUpNode(id)
 	if n == nil {
 		return ErrNodeNotFound
 	}

--- a/swarm/network/simulation/events.go
+++ b/swarm/network/simulation/events.go
@@ -18,6 +18,7 @@ package simulation
 
 import (
 	"context"
+	"sync"
 
 	"github.com/ethereum/go-ethereum/p2p/discover"
 
@@ -71,23 +72,31 @@ func (f *PeerEventsFilter) MsgCode(c uint64) *PeerEventsFilter {
 func (s *Simulation) PeerEvents(ctx context.Context, ids []discover.NodeID, filters ...*PeerEventsFilter) <-chan PeerEvent {
 	eventC := make(chan PeerEvent)
 
+	// wait group to make sure all subscriptons to admin peerEvents are established
+	// before this function returns.
+	var subsWG sync.WaitGroup
 	for _, id := range ids {
 		s.shutdownWG.Add(1)
+		subsWG.Add(1)
 		go func(id discover.NodeID) {
 			defer s.shutdownWG.Done()
 
 			client, err := s.Net.GetNode(id).Client()
 			if err != nil {
+				subsWG.Done()
 				eventC <- PeerEvent{NodeID: id, Error: err}
 				return
 			}
 			events := make(chan *p2p.PeerEvent)
 			sub, err := client.Subscribe(ctx, "admin", events, "peerEvents")
 			if err != nil {
+				subsWG.Done()
 				eventC <- PeerEvent{NodeID: id, Error: err}
 				return
 			}
 			defer sub.Unsubscribe()
+
+			subsWG.Done()
 
 			for {
 				select {
@@ -153,5 +162,7 @@ func (s *Simulation) PeerEvents(ctx context.Context, ids []discover.NodeID, filt
 		}(id)
 	}
 
+	// wait all subscriptions
+	subsWG.Wait()
 	return eventC
 }

--- a/swarm/network/simulation/node.go
+++ b/swarm/network/simulation/node.go
@@ -294,7 +294,7 @@ func (s *Simulation) StopNode(id discover.NodeID) (err error) {
 
 // StopRandomNode stops a random node.
 func (s *Simulation) StopRandomNode() (id discover.NodeID, err error) {
-	n := s.randomUpNode()
+	n := s.RandomUpNode()
 	if n == nil {
 		return id, ErrNodeNotFound
 	}
@@ -324,18 +324,18 @@ func init() {
 	rand.Seed(time.Now().UnixNano())
 }
 
-// randomUpNode returns a random SimNode that is up.
+// RandomUpNode returns a random SimNode that is up.
 // Arguments are NodeIDs for nodes that should not be returned.
-func (s *Simulation) randomUpNode(exclude ...discover.NodeID) *adapters.SimNode {
+func (s *Simulation) RandomUpNode(exclude ...discover.NodeID) *adapters.SimNode {
 	return s.randomNode(s.UpNodeIDs(), exclude...)
 }
 
-// randomUpNode returns a random SimNode that is not up.
+// randomDownNode returns a random SimNode that is not up.
 func (s *Simulation) randomDownNode(exclude ...discover.NodeID) *adapters.SimNode {
 	return s.randomNode(s.DownNodeIDs(), exclude...)
 }
 
-// randomUpNode returns a random SimNode from the slice of NodeIDs.
+// randomNode returns a random SimNode from the slice of NodeIDs.
 func (s *Simulation) randomNode(ids []discover.NodeID, exclude ...discover.NodeID) *adapters.SimNode {
 	for _, e := range exclude {
 		var i int

--- a/swarm/network/simulation/service.go
+++ b/swarm/network/simulation/service.go
@@ -39,7 +39,7 @@ func (s *Simulation) Service(name string, id discover.NodeID) node.Service {
 // RandomService returns a single Service by name on a
 // randomly chosen node that is up.
 func (s *Simulation) RandomService(name string) node.Service {
-	n := s.randomUpNode()
+	n := s.RandomUpNode()
 	if n == nil {
 		return nil
 	}

--- a/swarm/network/stream/common_test.go
+++ b/swarm/network/stream/common_test.go
@@ -384,6 +384,10 @@ func uploadFilesToNodes(sim *simulation.Simulation) ([]storage.Address, []string
 	return rootAddrs, rfiles, nil
 }
 
+func init() {
+	rand.Seed(time.Now().UnixNano())
+}
+
 //generate a random file (string)
 func generateRandomFile() (string, error) {
 	//generate a random file size between minFileSize and maxFileSize

--- a/swarm/network/stream/snapshot_retrieval_test.go
+++ b/swarm/network/stream/snapshot_retrieval_test.go
@@ -18,7 +18,6 @@ package stream
 import (
 	"context"
 	"fmt"
-	"math/rand"
 	"os"
 	"sync"
 	"testing"
@@ -343,17 +342,15 @@ func runRetrievalTest(chunkCount int, nodeCount int) error {
 		//uploadFinished := make(chan struct{})
 		//channel to trigger new node checks
 
-		//select one index at random...
-		idx := rand.Intn(len(nodeIDs))
-		//...and get the the node at that index
+		//get the the node at that index
 		//this is the node selected for upload
-		node := nodeIDs[idx]
-		item, ok := sim.NodeItem(node, bucketKeyStore)
+		node := sim.RandomUpNode()
+		item, ok := sim.NodeItem(node.ID, bucketKeyStore)
 		if !ok {
 			return fmt.Errorf("No localstore")
 		}
 		lstore := item.(*storage.LocalStore)
-		conf.hashes, err = uploadFileToSingleNodeStore(node, chunkCount, lstore)
+		conf.hashes, err = uploadFileToSingleNodeStore(node.ID, chunkCount, lstore)
 		if err != nil {
 			return err
 		}

--- a/swarm/network/stream/snapshot_sync_test.go
+++ b/swarm/network/stream/snapshot_sync_test.go
@@ -20,7 +20,6 @@ import (
 	crand "crypto/rand"
 	"fmt"
 	"io"
-	"math/rand"
 	"os"
 	"sync"
 	"testing"
@@ -54,10 +53,6 @@ type synctestConfig struct {
 	idToChunksMap    map[discover.NodeID][]int
 	chunksToNodesMap map[string][]int
 	addrToIdMap      map[string]discover.NodeID
-}
-
-func init() {
-	rand.Seed(time.Now().Unix())
 }
 
 //This test is a syncing test for nodes.
@@ -191,17 +186,15 @@ func testSyncing(t *testing.T, chunkCount int, nodeCount int) {
 			conf.addrToIdMap[string(a)] = n
 		}
 
-		//select one index at random...
-		idx := rand.Intn(len(nodeIDs))
-		//...and get the the node at that index
+		//get the the node at that index
 		//this is the node selected for upload
-		node := nodeIDs[idx]
-		item, ok := sim.NodeItem(node, bucketKeyStore)
+		node := sim.RandomUpNode()
+		item, ok := sim.NodeItem(node.ID, bucketKeyStore)
 		if !ok {
 			return fmt.Errorf("No localstore")
 		}
 		lstore := item.(*storage.LocalStore)
-		hashes, err := uploadFileToSingleNodeStore(node, chunkCount, lstore)
+		hashes, err := uploadFileToSingleNodeStore(node.ID, chunkCount, lstore)
 		if err != nil {
 			return err
 		}
@@ -403,17 +396,15 @@ func runSyncTest(chunkCount int, nodeCount int) error {
 				}
 			}
 		}()
-		//select one index at random...
-		idx := rand.Intn(len(nodeIDs))
-		//...and get the the node at that index
+		//get the the node at that index
 		//this is the node selected for upload
-		node := nodeIDs[idx]
-		item, ok := sim.NodeItem(node, bucketKeyStore)
+		node := sim.RandomUpNode()
+		item, ok := sim.NodeItem(node.ID, bucketKeyStore)
 		if !ok {
 			return fmt.Errorf("No localstore")
 		}
 		lstore := item.(*storage.LocalStore)
-		hashes, err := uploadFileToSingleNodeStore(node, chunkCount, lstore)
+		hashes, err := uploadFileToSingleNodeStore(node.ID, chunkCount, lstore)
 		if err != nil {
 			return err
 		}

--- a/swarm/network/stream/snapshot_sync_test.go
+++ b/swarm/network/stream/snapshot_sync_test.go
@@ -384,18 +384,15 @@ func runSyncTest(chunkCount int, nodeCount int) error {
 			subscriptionCount += cnt
 		}
 
-		go func() {
-			for e := range eventC {
-				if e.Error != nil {
-					//return e.Error
-					return
-				}
-				subscriptionCount--
-				if subscriptionCount == 0 {
-					break
-				}
+		for e := range eventC {
+			if e.Error != nil {
+				return e.Error
 			}
-		}()
+			subscriptionCount--
+			if subscriptionCount == 0 {
+				break
+			}
+		}
 		//get the the node at that index
 		//this is the node selected for upload
 		node := sim.RandomUpNode()


### PR DESCRIPTION
Hi, this is a change related to https://github.com/ethersphere/go-ethereum/pull/798#discussion_r203674414.